### PR TITLE
fix some dialyzer issues

### DIFF
--- a/src/erl_cache.erl
+++ b/src/erl_cache.erl
@@ -84,8 +84,9 @@
                     {miss, non_neg_integer()}.
 -type cache_stats()::[cache_stat()].
 
--type config_key()::validity | evict | refresh_callback | wait_for_refresh
-                  | wait_until_done | evict_interval | is_error_callback | error_validity.
+-type config_key()::validity | evict | refresh_callback | wait_for_refresh | max_cache_size
+                  | wait_until_done | evict_interval | error_validity | is_error_callback
+                  | mem_check_interval | key_generation.
 
 -type callback() :: function() | mfa().
 


### PR DESCRIPTION
#### Problem Description

Dependent project suffers from dialyzer issues such as:
`src/erl_cache.erl:156: The call erl_cache:validate_opts(CacheOpts::any(),[]) will never return since it differs in the 2nd argument from the success typing arguments: (any(),'undefined')
src/erl_cache.erl:157: The pattern {'ok', ValidatedOpts} can never match the type {'error',{'invalid','cache_name'}}
src/erl_cache.erl:202: The pattern {'ok', ValidatedOpts} can never match the type {'error',{'invalid','cache_name'}}
src/erl_cache.erl:229: The pattern {'ok', ValidatedOpts} can never match the type {'error',{'invalid','cache_name'}}
src/erl_cache.erl:252: The pattern {'ok', ValidatedOpts} can never match the type {'error',{'invalid','cache_name'}}
src/erl_cache.erl:300: The call erl_cache:validate_opts(Opts::any(),[]) will never return since it differs in the 2nd argument from the success typing arguments: (any(),'undefined')
src/erl_cache.erl:301: The pattern {'ok', ValidatedOpts} can never match the type {'error',{'invalid','cache_name'}}
src/erl_cache.erl:397: The call erl_cache:default(Key::'key_generation',Defaults::[{'error_validity' | 'evict' | 'evict_interval' | 'is_error_callback' | 'key_generation' | 'max_cache_size' | 'mem_check_interval' | 'refresh_callback' | 'validity' | 'wait_for_refresh' | 'wait_until_done',atom() | fun() | non_neg_integer() | {_,_,_}}]) breaks the contract (config_key(),cache_opts()) -> term()`
#### Solution Description

All these issues caused by single type _config_key()_
This change doesn't touch real functionality. So it can be merged without careful testing. It just makes dialyzer little bit more happy.
